### PR TITLE
add predict.py script

### DIFF
--- a/alignn/train.py
+++ b/alignn/train.py
@@ -844,7 +844,7 @@ def train_dgl(
         #    history["validation"][metric].append(vmetrics[metric])
 
         if config.store_outputs:
-            history["EOS"] = eos.data
+            history["EOS"] = train_eos.data
             history["trainEOS"] = train_eos.data
             dumpjson(
                 filename=os.path.join(config.output_dir, "history_val.json"),
@@ -1027,10 +1027,12 @@ def train_dgl(
             )
             # TODO: Add IDs
             f.write("target,prediction\n")
-            for i, j in zip(x, y):
-                f.write("%6f, %6f\n" % (j, i))
-                line = str(i) + "," + str(j) + "\n"
-                f.write(line)
+            #for i, j in zip(x, y):
+                #f.write("%6f, %6f\n" % (j, i))
+                #line = str(i) + "," + str(j) + "\n"
+               # f.write(line)
+            for target_val, predicted_val in zip(x, y):
+                print(f”{target_val}, {predicted_val}”, file=f)
             f.close()
 
     # TODO: Fix IDs for train loader

--- a/alignn/train.py
+++ b/alignn/train.py
@@ -844,7 +844,7 @@ def train_dgl(
         #    history["validation"][metric].append(vmetrics[metric])
 
         if config.store_outputs:
-            history["EOS"] = train_eos.data
+            history["EOS"] = eos.data
             history["trainEOS"] = train_eos.data
             dumpjson(
                 filename=os.path.join(config.output_dir, "history_val.json"),
@@ -1014,7 +1014,7 @@ def train_dgl(
         if config.store_outputs and not classification:
             x = []
             y = []
-            for i in history["EOS"]:
+            for i in history["trainEOS"]:
                 x.append(i[0].cpu().numpy().tolist())
                 y.append(i[1].cpu().numpy().tolist())
             x = np.array(x, dtype="float").flatten()
@@ -1027,12 +1027,8 @@ def train_dgl(
             )
             # TODO: Add IDs
             f.write("target,prediction\n")
-            #for i, j in zip(x, y):
-                #f.write("%6f, %6f\n" % (j, i))
-                #line = str(i) + "," + str(j) + "\n"
-               # f.write(line)
             for target_val, predicted_val in zip(x, y):
-                print(f”{target_val}, {predicted_val}”, file=f)
+                print(f"{target_val}, {predicted_val}", file=f)
             f.close()
 
     # TODO: Fix IDs for train loader

--- a/alignn/train.py
+++ b/alignn/train.py
@@ -1012,24 +1012,25 @@ def train_dgl(
             mean_absolute_error(np.array(targets), np.array(predictions)),
         )
         if config.store_outputs and not classification:
-            x = []
-            y = []
-            for i in history["trainEOS"]:
-                x.append(i[0].cpu().numpy().tolist())
-                y.append(i[1].cpu().numpy().tolist())
-            x = np.array(x, dtype="float").flatten()
-            y = np.array(y, dtype="float").flatten()
-            f = open(
-                os.path.join(
-                    config.output_dir, "prediction_results_train_set.csv"
-                ),
-                "w",
-            )
+            # save training targets and predictions here
             # TODO: Add IDs
-            f.write("target,prediction\n")
-            for target_val, predicted_val in zip(x, y):
-                print(f"{target_val}, {predicted_val}", file=f)
-            f.close()
+            resultsfile = os.path.join(
+                config.output_dir, "prediction_results_train_set.csv"
+            )
+
+            target_vals, predictions = [], []
+
+            for tgt, pred in history["trainEOS"]:
+                target_vals.append(tgt.cpu().numpy().tolist())
+                predictions.append(pred.cpu().numpy().tolist())
+
+            target_vals = np.array(target_vals, dtype="float").flatten()
+            predictions = np.array(predictions, dtype="float").flatten()
+
+            with open(resultsfile, "w") as f:
+                print("target,prediction", file=f)
+                for target_val, predicted_val in zip(target_vals, predictions):
+                    print(f"{target_val}, {predicted_val}", file=f)
 
     # TODO: Fix IDs for train loader
     """


### PR DESCRIPTION
The current pretrained.py script can be used for only one file, and it always wants to download the pretrained checkpoint from Figshare even though someone would like to pass it by feeding their own checkpoint. 

This predict.py script can be used to apply an optimized model to a new dataset. After running this script, it will generate a csv file with an id and the corresponding prediction. Note, you have to keep, the id_prop.csv file in the target folder. 

