### PR TITLE
rename profiling module to avoid name collision with builtin profile

### DIFF
--- a/alignn/cli.py
+++ b/alignn/cli.py
@@ -12,7 +12,7 @@ import torch
 import typer
 
 from alignn.config import TrainingConfig
-from alignn.profile import profile_dgl
+from alignn.profiler import profile_dgl
 from alignn.train import train_dgl
 
 

--- a/alignn/profiler.py
+++ b/alignn/profiler.py
@@ -1,7 +1,7 @@
 """pytorch profiling script.
 
 from the repository root, run
-`PYTHONPATH=$PYTHONPATH:. python jarvisdgl/profile.py`
+`PYTHONPATH=$PYTHONPATH:. python alignn/profiler.py`
 """
 
 from functools import partial


### PR DESCRIPTION
this PR addresses https://github.com/usnistgov/alignn/issues/158 which I think is due to a name collision with [the builtin profile module](https://docs.python.org/3/library/profile.html#module-profile) - see https://stackoverflow.com/a/57325589

the fix is to rename alignn/profile.py to alignn/profiler.py